### PR TITLE
fix: resolve critical interface and implementation bugs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
-Package Package loggerrific is a logging interface for abstracting the choice of logging framework
+Package loggerrific is a logging interface for abstracting the choice of logging framework
 for an application.
 
 For a full guide visit https://github.com/CallumKerson/loggerrific

--- a/logger.go
+++ b/logger.go
@@ -5,6 +5,11 @@ type Logger interface {
 	WithFields(fields map[string]interface{}) Entry
 	WithError(err error) Entry
 
+	SetLevelDebug()
+	SetLevelInfo()
+	SetLevelWarn()
+	SetLevelError()
+
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
 	Warnf(format string, args ...interface{})

--- a/noop/noop_logger.go
+++ b/noop/noop_logger.go
@@ -1,4 +1,4 @@
-// package noopt provides an no operation (noop) implementation of the l
+// Package noop provides a no operation (noop) implementation of the
 // loggerrific interface that can be used as a default implementation if no
 // other implementation is provided.
 package noop

--- a/tlogger/entry.go
+++ b/tlogger/entry.go
@@ -7,19 +7,19 @@ type TEntry struct {
 }
 
 func (e *TEntry) Debugf(format string, args ...interface{}) {
-	e.t.Logf("debug: "+format, args)
+	e.t.Logf("debug: "+format, args...)
 }
 
 func (e *TEntry) Infof(format string, args ...interface{}) {
-	e.t.Logf("info: "+format, args)
+	e.t.Logf("info: "+format, args...)
 }
 
 func (e *TEntry) Warnf(format string, args ...interface{}) {
-	e.t.Logf("warn: "+format, args)
+	e.t.Logf("warn: "+format, args...)
 }
 
 func (e *TEntry) Errorf(format string, args ...interface{}) {
-	e.t.Logf("error "+format, args)
+	e.t.Logf("error: "+format, args...)
 }
 
 func (e *TEntry) Debugln(args ...interface{}) {

--- a/tlogger/logger.go
+++ b/tlogger/logger.go
@@ -26,20 +26,28 @@ func (l *TLogger) WithError(_ error) loggerrific.Entry {
 	return &TEntry{t: l.T}
 }
 
+func (l *TLogger) SetLevelDebug() {}
+
+func (l *TLogger) SetLevelInfo() {}
+
+func (l *TLogger) SetLevelWarn() {}
+
+func (l *TLogger) SetLevelError() {}
+
 func (l *TLogger) Debugf(format string, args ...interface{}) {
-	l.T.Logf("debug: "+format, args)
+	l.T.Logf("debug: "+format, args...)
 }
 
 func (l *TLogger) Infof(format string, args ...interface{}) {
-	l.T.Logf("info: "+format, args)
+	l.T.Logf("info: "+format, args...)
 }
 
 func (l *TLogger) Warnf(format string, args ...interface{}) {
-	l.T.Logf("warn: "+format, args)
+	l.T.Logf("warn: "+format, args...)
 }
 
 func (l *TLogger) Errorf(format string, args ...interface{}) {
-	l.T.Logf("error "+format, args)
+	l.T.Logf("error: "+format, args...)
 }
 
 func (l *TLogger) Debugln(args ...interface{}) {


### PR DESCRIPTION
## Summary
- Add missing SetLevel methods to Logger interface to match README example
- Fix argument passing in tlogger implementations (args -> args...)
- Fix error formatting consistency in tlogger (missing colon)
- Fix redundant "Package Package" in doc.go
- Fix typo "noopt" -> "noop" in noop package comment
- Ensure all implementations conform to the complete interface

## Test plan
- [x] Interface changes validated for consistency
- [x] Implementation fixes tested
- [ ] CI should pass with corrected implementations

🤖 Generated with [Claude Code](https://claude.ai/code)